### PR TITLE
Perf: FeedPage, PostDetailPage SSR 적용

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,6 @@ export default async function FeedPage() {
       if (!response) {
         return { posts: [], nextPage: undefined };
       }
-      console.log("FeedPage prefetchInfiniteQuery response =>", response);
       return response;
     },
     initialPageParam: 1,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import FeedItem from "@/components/posts/FeedItem";
 import getQueryClient from "@/config/tanstack-query/get-query-client";
+import { customFetchServer } from "@/lib/fetch/server";
 import { POST_KEY } from "@/lib/posts/key";
+import { FetchPostsResponse } from "@/lib/posts/types";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 export default async function FeedPage() {
@@ -9,12 +11,14 @@ export default async function FeedPage() {
   await queryClient.prefetchInfiniteQuery({
     queryKey: [POST_KEY],
     queryFn: async () => {
-      console.log("Fetching data from server");
-      const res = await fetch(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/api/posts?page=1`
-      );
-      if (!res.ok) throw new Error("Failed to fetch initial posts");
-      return await res.json();
+      const response = await customFetchServer<FetchPostsResponse>({
+        endpoint: `/api/posts?page=1`,
+      });
+      if (!response) {
+        return { posts: [], nextPage: undefined };
+      }
+      console.log("FeedPage prefetchInfiniteQuery response =>", response);
+      return response;
     },
     initialPageParam: 1,
   });

--- a/src/components/posts/FeedItem.tsx
+++ b/src/components/posts/FeedItem.tsx
@@ -6,11 +6,8 @@ import { TPosts } from "@/lib/posts/types";
 import AddPostButton from "@/components/posts/AddPostButton";
 import { PostCardSkeleton } from "./PostCardSkeleton";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
-import { useAuthStore } from "@/store/auth/useAuthStore";
 
 export default function FeedItem() {
-  const { user } = useAuthStore();
-
   const {
     data,
     fetchNextPage,
@@ -18,7 +15,7 @@ export default function FeedItem() {
     isFetchingNextPage,
     isLoading,
     error,
-  } = useFetchPosts(user?.uid as string);
+  } = useFetchPosts();
 
   // 관찰 대상 ref
   const triggerRef = useIntersectionObserver({

--- a/src/lib/posts/hooks/useFetchPosts.ts
+++ b/src/lib/posts/hooks/useFetchPosts.ts
@@ -3,9 +3,9 @@ import { POST_KEY } from "../key";
 import { customFetchServer } from "@/lib/fetch/server";
 import { FetchPostsResponse } from "../types";
 
-export const useFetchPosts = (userId: string) => {
+export const useFetchPosts = () => {
   return useInfiniteQuery<FetchPostsResponse>({
-    queryKey: [POST_KEY, userId],
+    queryKey: [POST_KEY],
     queryFn: async ({ pageParam = 1 }) => {
       // 무한 스크롤: 클라이언트에서 쿼리 파라미터 전달
       const response = await customFetchServer<FetchPostsResponse>({


### PR DESCRIPTION
## #️⃣연관된 이슈

> #29 

## 작업 상세 내용

FeedPage
- 메인 페이지 프리페치 쿼리의 키 불일치 문제 해결
- 프리페치 데이터가 제대로 캐싱되도록 쿼리 키 일치화 적용
- Lighthouse  LCP 1.2s → 0.8s, Speed Index 0.8s → 0.5s로 개선 확인
- 프리페치가 정상 작동하여 화면 깜박임이 줄어듦

PostDetailPage
- prefetchQuery 사용하여 미리 데이터 가져오도록 개선
- Lighthouse 성능 81점→ 98점, LCP  1.0s → 0.8s, Speed Index 0.7s → 0.4s로 개선 확인
- 이미지 최적화 등 추가적인 성능 개선 필요

## 참고할만한 자료(선택)
