### PR TITLE
Feat: 사용자가 작성한 게시물만 조회, 팔로워/팔로잉 수 표시 & Fix: 프로필 수정 이슈 해결

### DIFF
--- a/src/app/(afterLogin)/layout.tsx
+++ b/src/app/(afterLogin)/layout.tsx
@@ -1,7 +1,7 @@
-export default function ServicesLayout({
+export default function Layout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <div className="w-inherit">{children}</div>;
+  return <div className="w-inherit h-full">{children}</div>;
 }

--- a/src/app/(afterLogin)/profile/[nickname]/page.tsx
+++ b/src/app/(afterLogin)/profile/[nickname]/page.tsx
@@ -1,4 +1,4 @@
-// import UserPostsSection from "@/components/profile/UserPostsSection";
+import UserPostsSection from "@/components/profile/UserPostsSection";
 import UserProfileSection from "@/components/profile/UserProfileSection";
 
 export default function ProfilePage({
@@ -10,7 +10,7 @@ export default function ProfilePage({
   return (
     <div>
       <UserProfileSection nickname={decodedNickname} />
-      {/* <UserPostsSection nickname={nickname} /> */}
+      <UserPostsSection />
     </div>
   );
 }

--- a/src/app/(beforeLogin)/layout.tsx
+++ b/src/app/(beforeLogin)/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 
-export default function AuthLayout({ children }: { children: ReactNode }) {
+export default function Layout({ children }: { children: ReactNode }) {
   return (
     <div className="p-2 gap-y-10 flex flex-col justify-center items-center h-svh">
       {children}

--- a/src/app/api/follows/list/route.ts
+++ b/src/app/api/follows/list/route.ts
@@ -1,0 +1,82 @@
+import { db } from "@/config/firebase/firebase";
+import { authenticateUser } from "@/lib/auth/authenticateUser";
+import { FOLLOWER_KEY, FOLLOWING_KEY } from "@/lib/follows/key";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+} from "firebase/firestore";
+import { NextRequest, NextResponse } from "next/server";
+
+interface FollowData {
+  id: string;
+  followerId: string;
+  followingId: string;
+}
+
+// 팔로워/팔로잉 목록 조회
+export async function GET(req: NextRequest) {
+  const type = req.nextUrl.searchParams.get("type");
+
+  const userId = await authenticateUser(req);
+  if (!userId) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  try {
+    let followsQuery;
+
+    if (type === FOLLOWER_KEY) {
+      // 내 팔로워 조회 (내가 followingId인 경우)
+      followsQuery = query(
+        collection(db, "follows"),
+        where("followingId", "==", userId)
+      );
+    } else if (type === FOLLOWING_KEY) {
+      // 내가 팔로우한 사람 조회 (내가 followerId인 경우)
+      followsQuery = query(
+        collection(db, "follows"),
+        where("followerId", "==", userId)
+      );
+    } else {
+      return NextResponse.json(
+        { error: "Invalid type parameter" },
+        { status: 400 }
+      );
+    }
+
+    // follows 컬렉션에서 팔로워/팔로잉 목록을 가져옴
+    const followsSnapshot = await getDocs(followsQuery);
+    const followsData: FollowData[] = followsSnapshot.docs.map(
+      (doc: { id: string; data: () => any }) => ({
+        id: doc.id,
+        ...doc.data(),
+      })
+    );
+
+    // follows의 각 userId로 users 컬렉션에서 사용자 정보 가져오기
+    const followUserInfos = await Promise.all(
+      followsData.map(async (follow) => {
+        const targetUserId =
+          type === FOLLOWER_KEY ? follow.followerId : follow.followingId;
+        const followUserRef = doc(db, "users", targetUserId);
+        const followUserDocSnap = await getDoc(followUserRef);
+        return { id: follow.id, ...followUserDocSnap.data() };
+      })
+    );
+
+    return NextResponse.json({ followsList: followUserInfos });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        message: "팔로우 목록 조회 중에 오류가 발생했습니다.",
+        error,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/follows/route.ts
+++ b/src/app/api/follows/route.ts
@@ -1,16 +1,6 @@
 import { db } from "@/config/firebase/firebase";
 import { authenticateUser } from "@/lib/auth/authenticateUser";
-import { FOLLOWER_KEY, FOLLOWING_KEY } from "@/lib/follows/key";
-import {
-  collection,
-  doc,
-  getDoc,
-  getDocs,
-  increment,
-  query,
-  runTransaction,
-  where,
-} from "firebase/firestore";
+import { doc, getDoc, increment, runTransaction } from "firebase/firestore";
 import { NextRequest, NextResponse } from "next/server";
 
 // 팔로우
@@ -75,69 +65,32 @@ export async function DELETE(req: NextRequest) {
   }
 }
 
-interface FollowData {
-  id: string;
-  followerId: string;
-  followingId: string;
-}
-
-// 팔로워/팔로잉 목록 조회
+// 팔로워/팔로잉 수 가져오기
 export async function GET(req: NextRequest) {
-  const type = req.nextUrl.searchParams.get("type");
-
   const userId = await authenticateUser(req);
   if (!userId) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
   try {
-    let followsQuery;
+    const userDocRef = doc(db, "users", userId);
+    const userDoc = await getDoc(userDocRef);
 
-    if (type === FOLLOWER_KEY) {
-      // 내 팔로워 조회 (내가 followingId인 경우)
-      followsQuery = query(
-        collection(db, "follows"),
-        where("followingId", "==", userId)
-      );
-    } else if (type === FOLLOWING_KEY) {
-      // 내가 팔로우한 사람 조회 (내가 followerId인 경우)
-      followsQuery = query(
-        collection(db, "follows"),
-        where("followerId", "==", userId)
-      );
-    } else {
-      return NextResponse.json(
-        { error: "Invalid type parameter" },
-        { status: 400 }
-      );
+    if (!userDoc.exists()) {
+      return new NextResponse("User not found", { status: 404 });
     }
 
-    // follows 컬렉션에서 팔로워/팔로잉 목록을 가져옴
-    const followsSnapshot = await getDocs(followsQuery);
-    const followsData: FollowData[] = followsSnapshot.docs.map((doc) => ({
-      id: doc.id,
-      ...doc.data(),
-    })) as FollowData[];
+    const data = userDoc.data();
+    const followersCount = data.followersCount || 0;
+    const followingsCount = data.followingsCount || 0;
 
-    // follows의 각 userId로 users 컬렉션에서 사용자 정보 가져오기
-    const followUserInfos = await Promise.all(
-      followsData.map(async (follow) => {
-        const targetUserId =
-          type === FOLLOWER_KEY ? follow.followerId : follow.followingId;
-        const followUserRef = doc(db, "users", targetUserId);
-        const followUserDocSnap = await getDoc(followUserRef);
-        return { id: follow.id, ...followUserDocSnap.data() };
-      })
-    );
-
-    return NextResponse.json({ followsList: followUserInfos });
+    return NextResponse.json({
+      status: 200,
+      data: { followersCount, followingsCount },
+    });
   } catch (error) {
     return NextResponse.json(
-      {
-        success: false,
-        message: "팔로우 목록 조회 중에 오류가 발생했습니다.",
-        error,
-      },
+      { error: "팔로우 수를 가져오는 중 오류가 발생했습니다.", details: error },
       { status: 500 }
     );
   }

--- a/src/app/api/posts/read-by-user/route.ts
+++ b/src/app/api/posts/read-by-user/route.ts
@@ -1,0 +1,50 @@
+import { db } from "@/config/firebase/firebase";
+import { authenticateUser } from "@/lib/auth/authenticateUser";
+import { collection, getDocs, query, where } from "firebase/firestore";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const searchParams = req.nextUrl.searchParams;
+  const page = Number(searchParams.get("page")) || 1;
+  const pageSize = Number(searchParams.get("pageSize")) || 4;
+
+  const userId = await authenticateUser(req);
+  if (!userId) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  try {
+    // 사용자가 작성한 게시물만 조회
+    const postsRef = collection(db, "posts");
+    const userPostsQuery = query(postsRef, where("userId", "==", userId));
+    const postSnapshots = await getDocs(userPostsQuery);
+
+    const posts = postSnapshots.docs.map((doc) => ({
+      ...doc.data(),
+      id: doc.id,
+      createdAt: doc.data().createdAt.toDate().toLocaleString(),
+    }));
+
+    // 페이징
+    const totalCount = posts.length;
+    const startIndex = (page - 1) * pageSize;
+    const endIndex = startIndex + pageSize;
+    const paginatedPosts = posts.slice(startIndex, endIndex);
+
+    const hasNextPage = endIndex < totalCount;
+    const nextPage = hasNextPage ? page + 1 : undefined;
+
+    return NextResponse.json({
+      totalCount,
+      posts: paginatedPosts,
+      hasNextPage,
+      nextPage,
+    });
+  } catch (error) {
+    console.error("Error fetching user posts: ", error);
+    return NextResponse.json(
+      { error: "사용자 게시물 페치에 실패했습니다." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/common/DotMenuButton.tsx
+++ b/src/components/common/DotMenuButton.tsx
@@ -20,14 +20,14 @@ export default function DotMenuButton({
     setIsMenuOpen(false);
   });
 
-  const { data: isFollowing, isLoading } = useIsFollowingQuery(
+  const { data: isFollowingState, isLoading } = useIsFollowingQuery(
     followerId,
     followingId
   );
   const { mutateAsync: followMutation } = useFollowMutation(
     followerId,
     followingId,
-    isFollowing
+    isFollowingState as boolean
   );
 
   const toggleMenu = () => {
@@ -54,7 +54,7 @@ export default function DotMenuButton({
             onClick={handleFollow}
             disabled={isLoading}
           >
-            {isFollowing ? "UnFollow" : "Follow"}
+            {isFollowingState ? "UnFollow" : "Follow"}
           </Button>
           <Button className="w-full" variant="ghost">
             Chat

--- a/src/components/posts/PhotoCard.tsx
+++ b/src/components/posts/PhotoCard.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { Card, CardContent } from "../ui/card";
+import Image from "next/image";
+
+export default function PhotoCard({
+  postId,
+  imageUrl,
+}: {
+  postId: string;
+  imageUrl: string;
+}) {
+  return (
+    <Card className="grow min-w-80 max-w-lg bg-white shadow-md rounded-lg">
+      <Link href={`/post/${postId}`}>
+        <CardContent className="p-0 bg-gray-200 relative min-h-48 max-h-80">
+          <Image
+            src={imageUrl || ""}
+            alt="Post Image"
+            fill={true}
+            style={{ objectFit: "cover" }}
+          />
+        </CardContent>
+      </Link>
+    </Card>
+  );
+}

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -60,7 +60,9 @@ export default function PostCard({
           {/* User Image */}
           <UserImage profileImage={user?.profileImage || ""} size="sm" />
           <div>
-            <CardTitle className="text-sm font-semibold">{userId}</CardTitle>
+            <CardTitle className="text-sm font-semibold">
+              {user?.nickname}
+            </CardTitle>
             <CardDescription className="text-xs text-gray-500">
               {elapsedTime(createdAt)}
             </CardDescription>
@@ -77,7 +79,6 @@ export default function PostCard({
             alt="User profile"
             fill={true}
             style={{ objectFit: "cover" }}
-            className=""
           />
         </CardContent>
 

--- a/src/components/profile/ProfileEditForm.tsx
+++ b/src/components/profile/ProfileEditForm.tsx
@@ -14,7 +14,7 @@ interface ProfileFormValues {
 }
 
 export default function ProfilEditForm() {
-  const { user, setUser } = useAuthStore();
+  const user = useAuthStore((state) => state.user);
   const userProfileImage = user?.profileImage;
   const userBio = user?.bio;
   const [imagePreview, setImagePreview] = useState<File | string | null>(
@@ -40,29 +40,13 @@ export default function ProfilEditForm() {
       formData.append("bio", data.bio);
     }
 
-    // 이미지를 변경하지 않았을 때 기존 이미지를 유지
-    if (typeof imagePreview === "string") {
-      formData.append("imageUrl", imagePreview);
+    // 이미지 처리
+    if (data.profileImage instanceof File) {
+      // 새 이미지 파일만 추가
+      formData.append("profileImage", data.profileImage);
     }
 
-    // 새 이미지 파일이 있을 때 추가
-    if (data.profileImage) {
-      formData.append("image", data.profileImage);
-    }
-    console.log("FormData in onSubmit:", Array.from(formData.entries()));
-
-    // 프로필 수정 API 호출
-    const updatedData = await editProfile(formData);
-
-    // 수정된 데이터를 Zustand 상태에 반영
-    setUser({
-      ...user,
-      bio: data.bio || userBio,
-      profileImage: updatedData.profileImage || userProfileImage,
-      uid: user?.uid || "",
-      email: user?.email || "",
-      nickname: user?.nickname || "",
-    });
+    await editProfile(formData);
   };
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/profile/UserPostsSection.tsx
+++ b/src/components/profile/UserPostsSection.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import PhotoCard from "../posts/PhotoCard";
+import { useFetchUserPosts } from "@/lib/posts/hooks/useFetchUserPosts";
+import useIntersectionObserver from "@/hooks/useIntersectionObserver";
+import { useAuthStore } from "@/store/auth/useAuthStore";
+import { TPosts } from "@/lib/posts/types";
+
+export default function UserPostsSection() {
+  const { user } = useAuthStore();
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    error,
+  } = useFetchUserPosts(user?.uid as string);
+
+  // 관찰 대상 ref
+  const triggerRef = useIntersectionObserver({
+    onIntersect: () => {
+      if (hasNextPage) fetchNextPage();
+    },
+    hasNextPage,
+  });
+
+  if (error) return <p>Error: {error.message}</p>;
+
+  const posts = data?.pages.flatMap((page) => page.posts) || [];
+
+  return (
+    <>
+      <section className="grid grid-cols-3 gap-1 p-1">
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : posts.length === 0 ? (
+          <p>현재 피드가 없습니다.</p>
+        ) : (
+          posts.map((post: TPosts) => (
+            <PhotoCard
+              key={post.id}
+              postId={post.id}
+              imageUrl={post.imageUrl || ""}
+            />
+          ))
+        )}
+      </section>
+      <div ref={triggerRef} className="min-w-80">
+        {isFetchingNextPage && (
+          <p className="text-center">Loading more posts...</p>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/profile/UserProfileInfo.tsx
+++ b/src/components/profile/UserProfileInfo.tsx
@@ -7,14 +7,18 @@ import IconButton from "../common/IconButton";
 import { Pencil2Icon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { PROFILE_ROUTES } from "@/constants/routes";
+import { useFetchFollowerCounts } from "@/lib/follows/hooks/useFetchFollowerCount";
 
 export default function UserProfileInfo({ nickname }: { nickname: string }) {
-  const { user } = useAuthStore();
+  const user = useAuthStore((state) => state.user);
   const isMyProfile = user?.nickname === nickname;
   const { data: otherUserData, isLoading } = useFetchProfile(nickname);
   const userData = isMyProfile ? user : otherUserData;
-  console.log("user", user);
+
+  const { data, error } = useFetchFollowerCounts(user?.uid as string);
+
   if (isLoading) return <p>Loading...</p>;
+  if (error) return <p>오류가 발생했습니다. {error.message}</p>;
 
   return (
     <div className="gap-y-6 flex flex-col items-center p-6 bg-gray-800 text-white">
@@ -35,6 +39,10 @@ export default function UserProfileInfo({ nickname }: { nickname: string }) {
         )}
       </div>
       <div>{userData?.nickname}</div>
+      <div className="flex justify-center space-x-4 text-sm">
+        <span>팔로워: {data?.followersCount}</span>
+        <span>팔로잉: {data?.followingsCount}</span>
+      </div>
       <div>{userData?.bio}</div>
     </div>
   );

--- a/src/components/profile/UserProfileSection.tsx
+++ b/src/components/profile/UserProfileSection.tsx
@@ -1,15 +1,8 @@
-// import FollowsList from "@/components/follows/FollowsList";
-// import { FOLLOWER_KEY, FOLLOWING_KEY } from "@/lib/follows/key";
-
 import UserProfileInfo from "./UserProfileInfo";
 
 export default function UserProfileSection({ nickname }: { nickname: string }) {
   return (
     <section className="">
-      <div>
-        {/* <FollowsList userId={userId} type={FOLLOWER_KEY} />
-        <FollowsList userId={userId} type={FOLLOWING_KEY} /> */}
-      </div>
       <UserProfileInfo nickname={nickname} />
     </section>
   );

--- a/src/lib/auth/api.ts
+++ b/src/lib/auth/api.ts
@@ -24,6 +24,8 @@ export const signUpAPI = async ({
   await setDoc(doc(db, "users", user.uid), {
     nickname,
     email,
+    bio: "",
+    profileImage: "",
   });
 
   return {

--- a/src/lib/follows/api.ts
+++ b/src/lib/follows/api.ts
@@ -1,0 +1,35 @@
+import { customServerRequest } from "@/utils/api/server";
+import { FetchFollowerCountsResponse, FetchIsFollowingResponse } from "./types";
+import { customClientRequest } from "@/utils/api/client";
+
+export const fetchFollowerCounts = async () => {
+  const response = await customServerRequest<FetchFollowerCountsResponse>({
+    endpoint: `/api/follows/`,
+  });
+  return response.data;
+};
+
+export const fetchIsFollowing = async (
+  followerId: string,
+  followingId: string
+) => {
+  const response = await customServerRequest<FetchIsFollowingResponse>({
+    endpoint: `/api/follows/is-following?followerId=${followerId}&followingId=${followingId}`,
+  });
+
+  return response.isFollowing;
+};
+
+export const updateFollow = async (
+  method: "DELETE" | "POST",
+  followerId: string,
+  followingId: string
+) => {
+  const response = await customClientRequest({
+    endpoint: "/api/follows",
+    method,
+    body: { followerId, followingId },
+  });
+
+  return response;
+};

--- a/src/lib/follows/hooks/useFetchFollowerCount.ts
+++ b/src/lib/follows/hooks/useFetchFollowerCount.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { queryOptions } from "../key";
+
+export const useFetchFollowerCounts = (userId: string) => {
+  const { queryKey: fetchFollowerCountsKey, queryFn: fetchFollowerCountsFn } =
+    queryOptions.followCounts(userId);
+  return useQuery({
+    queryKey: fetchFollowerCountsKey,
+    queryFn: fetchFollowerCountsFn,
+  });
+};

--- a/src/lib/follows/hooks/useFollowListQuery.ts
+++ b/src/lib/follows/hooks/useFollowListQuery.ts
@@ -10,8 +10,8 @@ export const useFollowListQuery = (userId: string, type: string) => {
   return useQuery({
     queryKey: [type, userId],
     queryFn: async () => {
-      const response = await fetch(`/api/follows?type=${type}`, {
-        headers: { "Content-Type": "application/json", "user-id": userId },
+      const response = await fetch(`/api/follows/list?type=${type}`, {
+        headers: { "Content-Type": "application/json" },
       });
       if (!response.ok) {
         throw new Error(`Failed to fetch ${type} list`);

--- a/src/lib/follows/hooks/useFollowMutation.ts
+++ b/src/lib/follows/hooks/useFollowMutation.ts
@@ -1,51 +1,31 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { FOLLOWER_KEY, FOLLOWING_KEY } from "../key";
+import { queryKeys } from "../key";
+import { updateFollow } from "../api";
 
 export function useFollowMutation(
   followingId: string,
   followerId: string,
-  isFollowing: boolean
+  isFollowingState: boolean
 ) {
   const queryClient = useQueryClient();
+  const isFollowingQueryKey = queryKeys.isFollowing(followerId, followingId);
+  const followerCountsKey = queryKeys.followCounts(followerId);
+  const method = isFollowingState ? "DELETE" : "POST";
 
   return useMutation({
-    mutationFn: async () => {
-      const method = isFollowing ? "DELETE" : "POST";
-
-      const response = await fetch(`/api/follows`, {
-        method,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ followerId, followingId }),
-      });
-
-      if (!response.ok) throw new Error("Failed to update follow status");
-
-      return response.json();
+    mutationFn: () => {
+      return updateFollow(method, followerId, followingId);
     },
     // 낙관적 업데이트를 사용해 UI에 즉각 반영
     onMutate: async () => {
       await queryClient.cancelQueries({
-        queryKey: [FOLLOWING_KEY, followerId, followingId],
+        queryKey: isFollowingQueryKey,
       });
 
-      const previousIsFollowing = queryClient.getQueryData([
-        FOLLOWING_KEY,
-        followerId,
-        followingId,
-      ]);
+      const previousIsFollowing = queryClient.getQueryData(isFollowingQueryKey);
 
       // 현재 팔로우 상태 낙관적 업데이트
-      queryClient.setQueryData(
-        [FOLLOWING_KEY, followerId, followingId],
-        !isFollowing
-      );
-
-      // 팔로우/언팔로우에 따른 팔로워 카운트 변경
-      // if (isFollowing) {
-      //   decrementFollowersCount();
-      // } else {
-      //   incrementFollowersCount();
-      // }
+      queryClient.setQueryData(isFollowingQueryKey, !isFollowingState);
 
       // 낙관적 업데이트가 실패할 경우를 대비해 이전 데이터 반환
       return { previousIsFollowing };
@@ -54,23 +34,19 @@ export function useFollowMutation(
     onError: (err, isFollowing, context) => {
       if (context?.previousIsFollowing) {
         queryClient.setQueryData(
-          [FOLLOWING_KEY, followerId, followingId],
+          isFollowingQueryKey,
           context.previousIsFollowing
         );
       }
-      // 카운트 상태도 롤백
-      // if (isFollowing) {
-      //   incrementFollowersCount();
-      // } else {
-      //   decrementFollowersCount();
-      // }
     },
     // 성공 또는 실패 후 쿼리 무효화하여 서버에서 최신 데이터 재요청
     onSettled: () => {
       queryClient.invalidateQueries({
-        queryKey: [FOLLOWING_KEY, followerId, followingId],
+        queryKey: isFollowingQueryKey,
       });
-      queryClient.invalidateQueries({ queryKey: [FOLLOWER_KEY] });
+      queryClient.invalidateQueries({
+        queryKey: followerCountsKey,
+      });
     },
   });
 }

--- a/src/lib/follows/hooks/useIsFollowingQuery.ts
+++ b/src/lib/follows/hooks/useIsFollowingQuery.ts
@@ -1,21 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
-import { FOLLOWING_KEY } from "../key";
+import { queryOptions } from "../key";
 
 export const useIsFollowingQuery = (
   followerId: string,
   followingId: string
 ) => {
+  const { queryKey: fetchIsFollowingKey, queryFn: fetchIsFollowingFn } =
+    queryOptions.isFollowing(followerId, followingId);
   return useQuery({
-    queryKey: [FOLLOWING_KEY, followerId, followingId],
-    queryFn: async () => {
-      const response = await fetch(
-        `/api/follows/is-following?followerId=${followerId}&followingId=${followingId}`
-      );
-      if (!response.ok) {
-        throw new Error("Failed to fetch follow status");
-      }
-      const data = await response.json();
-      return data.isFollowing;
-    },
+    queryKey: fetchIsFollowingKey,
+    queryFn: fetchIsFollowingFn,
   });
 };

--- a/src/lib/follows/key.ts
+++ b/src/lib/follows/key.ts
@@ -1,2 +1,24 @@
+import { fetchFollowerCounts, fetchIsFollowing } from "./api";
+
 export const FOLLOWER_KEY = "FOLLOWERS";
 export const FOLLOWING_KEY = "FOLLOWING";
+
+export const queryKeys = {
+  isFollowing: (followerId: string, followingId: string) => [
+    FOLLOWING_KEY,
+    followerId,
+    followingId,
+  ],
+  followCounts: (userId: string) => [FOLLOWER_KEY, FOLLOWING_KEY, userId],
+};
+
+export const queryOptions = {
+  isFollowing: (followerId: string, followingId: string) => ({
+    queryKey: queryKeys.isFollowing(followerId, followingId),
+    queryFn: () => fetchIsFollowing(followerId, followingId),
+  }),
+  followCounts: (userId: string) => ({
+    queryKey: queryKeys.followCounts(userId),
+    queryFn: fetchFollowerCounts,
+  }),
+};

--- a/src/lib/follows/types.ts
+++ b/src/lib/follows/types.ts
@@ -1,0 +1,10 @@
+export interface FetchFollowerCountsResponse {
+  data: {
+    followersCount: number;
+    followingsCount: number;
+  };
+}
+
+export interface FetchIsFollowingResponse {
+  isFollowing: boolean;
+}

--- a/src/lib/posts/api.ts
+++ b/src/lib/posts/api.ts
@@ -25,7 +25,7 @@ export const fetchUserPosts = async ({
   pageParam = 1,
 }: QueryFunctionContext) => {
   const response = await customServerRequest<FetchPostsResponse>({
-    endpoint: `/api/posts/readByUser?page=${pageParam}`,
+    endpoint: `/api/posts/read-by-user?page=${pageParam}`,
   });
   if (!response) {
     return { posts: [], nextPage: undefined };

--- a/src/lib/posts/hooks/useFetchUserPosts.ts
+++ b/src/lib/posts/hooks/useFetchUserPosts.ts
@@ -1,0 +1,14 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { queryOptions } from "../key";
+
+export const useFetchUserPosts = (userId: string) => {
+  const { queryKey: fetchUserPostsKey, queryFn: fetchUserPostsFn } =
+    queryOptions.userPosts(userId);
+
+  return useInfiniteQuery({
+    queryKey: fetchUserPostsKey,
+    queryFn: fetchUserPostsFn,
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => lastPage.nextPage,
+  });
+};

--- a/src/lib/user/hooks/useEditProfile.ts
+++ b/src/lib/user/hooks/useEditProfile.ts
@@ -3,16 +3,29 @@ import { useToastStore } from "@/store/toast/useToastStore";
 import { queryKeys } from "../key";
 import { updateUserProfile } from "../api";
 import { EditProfileResponse } from "../types";
+import { useAuthStore } from "@/store/auth/useAuthStore";
 
 export const useEditProfile = (nickname: string) => {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
+  const user = useAuthStore((state) => state.user);
+  const setUser = useAuthStore((state) => state.setUser);
 
   return useMutation<EditProfileResponse, Error, FormData>({
     mutationFn: (formData) => updateUserProfile(nickname, formData),
-    onSuccess: () => {
+    onSuccess: (response) => {
+      const data = response?.data;
+
       queryClient.invalidateQueries({
         queryKey: queryKeys.userProfile(nickname),
+      });
+
+      setUser({
+        bio: data.bio || user?.bio,
+        profileImage: data.profileImage || user?.profileImage,
+        uid: user?.uid || "",
+        email: user?.email || "",
+        nickname: user?.nickname || "",
       });
 
       addToast("프로필 수정 성공!", "success");

--- a/src/lib/user/types.ts
+++ b/src/lib/user/types.ts
@@ -5,6 +5,8 @@ export interface FetchProfileResponse {
 }
 
 export interface EditProfileResponse {
-  bio: string;
-  profileImage: string;
+  data: {
+    bio: string;
+    profileImage: string;
+  };
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #38 

## 작업 상세 내용

1. 프로필 페이지에서 해당 사용자가 작성한 게시물만 조회 기능 추가, 무한 스크롤 적용
2. 팔로워/팔로잉 수 표시 및 쿼리키 체계화 적용

3. 프로필 수정 이슈 해결
- 문제 원인:
  - 서버 응답이 중첩 구조(response.data)로 되어 있어 profileImage가 undefined로 처리되는 문제.
  - Zustand 상태와 React Query 캐시가 동기화되지 않아 UI가 최신 데이터를 반영하지 못함.
  - 회원가입 시 bio와 profileImage 필드가 없어서 데이터 구조가 불일치함.
- 해결:
  - 중첩된 응답 구조를 명시적으로 처리하여 올바른 데이터를 참조하도록 수정.
  - onSuccess에서 setUser를 호출하여 Zustand 상태와 React Query 데이터 간 동기화를 보장.
  - 회원가입 시 bio와 profileImage 필드를 추가하여 데이터 구조의 일관성을 유지.

