### PR TITLE
Feat: 프로필 페이지 SSR 및 prefetch 최적화

### DIFF
--- a/src/app/(afterLogin)/profile/[nickname]/page.tsx
+++ b/src/app/(afterLogin)/profile/[nickname]/page.tsx
@@ -1,16 +1,68 @@
 import UserPostsSection from "@/components/profile/UserPostsSection";
 import UserProfileSection from "@/components/profile/UserProfileSection";
+import getQueryClient from "@/config/tanstack-query/get-query-client";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { queryOptions as userQueryOptions } from "@/lib/user/key";
+import { queryOptions as postsQueryOptions } from "@/lib/posts/key";
+import { queryOptions as followQueryOptions } from "@/lib/follows/key";
+import { cookies } from "next/headers";
+import { decodeAccessToken } from "@/lib/auth/decodeAccessToken";
 
-export default function ProfilePage({
+export default async function ProfilePage({
   params: { nickname },
 }: {
   params: { nickname: string };
 }) {
   const decodedNickname = decodeURIComponent(nickname);
+  const accessToken = cookies().get("accessToken")?.value;
+  const userId = await decodeAccessToken(accessToken as string);
+
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
+  const queryClient = getQueryClient();
+
+  // Prefetch user profile
+  const { queryKey: fetchProfileKey, queryFn: fetchProfileFn } =
+    userQueryOptions.userProfile(decodedNickname);
+
+  // Prefetch user posts
+  const { queryKey: fetchUserPostsKey, queryFn: fetchUserPostsFn } =
+    postsQueryOptions.userPosts(userId);
+
+  // Prefetch follower counts
+  const { queryKey: fetchFollowerCountsKey, queryFn: fetchFollowerCountsFn } =
+    followQueryOptions.followCounts(userId);
+
+  await Promise.all([
+    queryClient
+      .prefetchQuery({
+        queryKey: fetchProfileKey,
+        queryFn: fetchProfileFn,
+      })
+      .then(() => console.log("Prefetched profile")),
+    queryClient
+      .prefetchInfiniteQuery({
+        queryKey: fetchUserPostsKey,
+        queryFn: fetchUserPostsFn,
+        initialPageParam: 1,
+      })
+      .then(() => console.log("Prefetched user posts")),
+    queryClient
+      .prefetchQuery({
+        queryKey: fetchFollowerCountsKey,
+        queryFn: fetchFollowerCountsFn,
+      })
+      .then(() => console.log("Prefetched follower counts")),
+  ]);
+
+  const dehydratedState = dehydrate(queryClient);
+
   return (
-    <div>
-      <UserProfileSection nickname={decodedNickname} />
-      <UserPostsSection />
-    </div>
+    <HydrationBoundary state={dehydratedState}>
+      <UserProfileSection nickname={decodedNickname} userId={userId} />
+      <UserPostsSection userId={userId} />
+    </HydrationBoundary>
   );
 }

--- a/src/components/profile/UserPostsSection.tsx
+++ b/src/components/profile/UserPostsSection.tsx
@@ -3,11 +3,9 @@
 import PhotoCard from "../posts/PhotoCard";
 import { useFetchUserPosts } from "@/lib/posts/hooks/useFetchUserPosts";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
-import { useAuthStore } from "@/store/auth/useAuthStore";
 import { TPosts } from "@/lib/posts/types";
 
-export default function UserPostsSection() {
-  const { user } = useAuthStore();
+export default function UserPostsSection({ userId }: { userId: string }) {
   const {
     data,
     fetchNextPage,
@@ -15,7 +13,7 @@ export default function UserPostsSection() {
     isFetchingNextPage,
     isLoading,
     error,
-  } = useFetchUserPosts(user?.uid as string);
+  } = useFetchUserPosts(userId);
 
   // 관찰 대상 ref
   const triggerRef = useIntersectionObserver({

--- a/src/components/profile/UserProfileInfo.tsx
+++ b/src/components/profile/UserProfileInfo.tsx
@@ -9,13 +9,19 @@ import Link from "next/link";
 import { PROFILE_ROUTES } from "@/constants/routes";
 import { useFetchFollowerCounts } from "@/lib/follows/hooks/useFetchFollowerCount";
 
-export default function UserProfileInfo({ nickname }: { nickname: string }) {
+export default function UserProfileInfo({
+  nickname,
+  userId,
+}: {
+  nickname: string;
+  userId: string;
+}) {
   const user = useAuthStore((state) => state.user);
   const isMyProfile = user?.nickname === nickname;
   const { data: otherUserData, isLoading } = useFetchProfile(nickname);
   const userData = isMyProfile ? user : otherUserData;
 
-  const { data, error } = useFetchFollowerCounts(user?.uid as string);
+  const { data, error } = useFetchFollowerCounts(userId);
 
   if (isLoading) return <p>Loading...</p>;
   if (error) return <p>오류가 발생했습니다. {error.message}</p>;

--- a/src/components/profile/UserProfileSection.tsx
+++ b/src/components/profile/UserProfileSection.tsx
@@ -1,9 +1,15 @@
 import UserProfileInfo from "./UserProfileInfo";
 
-export default function UserProfileSection({ nickname }: { nickname: string }) {
+export default function UserProfileSection({
+  nickname,
+  userId,
+}: {
+  nickname: string;
+  userId: string;
+}) {
   return (
     <section className="">
-      <UserProfileInfo nickname={nickname} />
+      <UserProfileInfo nickname={nickname} userId={userId} />
     </section>
   );
 }

--- a/src/lib/follows/hooks/useFetchFollowerCount.ts
+++ b/src/lib/follows/hooks/useFetchFollowerCount.ts
@@ -4,8 +4,10 @@ import { queryOptions } from "../key";
 export const useFetchFollowerCounts = (userId: string) => {
   const { queryKey: fetchFollowerCountsKey, queryFn: fetchFollowerCountsFn } =
     queryOptions.followCounts(userId);
+
   return useQuery({
     queryKey: fetchFollowerCountsKey,
     queryFn: fetchFollowerCountsFn,
+    enabled: !!userId,
   });
 };

--- a/src/lib/posts/hooks/useFetchUserPosts.ts
+++ b/src/lib/posts/hooks/useFetchUserPosts.ts
@@ -10,5 +10,6 @@ export const useFetchUserPosts = (userId: string) => {
     queryFn: fetchUserPostsFn,
     initialPageParam: 1,
     getNextPageParam: (lastPage) => lastPage.nextPage,
+    enabled: !!userId,
   });
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

>#29, #38

## 작업 상세 내용

- Promise.all로 prefetchInfiniteQuery 및 prefetchQuery 병렬 처리:
  - 사용자 프로필, 게시물, 팔로워 데이터를 동시에 프리페치하여 초기 로드 성능 개선
- 프리페치 데이터 활용 문제 해결:
  - userId를 props로 전달: useAuthStore 대신 props를 사용하여 초기값 null 문제 해결
  - enabled 옵션 추가: userId가 null 또는 undefined일 경우 쿼리 실행을 방지하여 불필요한 네트워크 요청 제거

[Lighthouse 주요 개선 내용]
- LCP: 1.1s → 0.5s로 개선
- Speed Index: 0.9s → 0.5s로 시각적 안정성 향상
- 성능 점수: 98점 → 100점으로 향상

